### PR TITLE
fix supervisor restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,8 @@
 - name: restart supervisor
   service:
     name: supervisor
-    state: restarted
+    state: stopped
+  service:
+    name: supervisor
+    state: started
   when: supervisor_state == 'started'


### PR DESCRIPTION
restarting supervisor by relying on it's init script 'restart' parameter doesn't work on Debian correctly, resulting in a failure. The problem is not supervisor itself, but rather it's init scripts. A service stop followed by a service start is necessary. A bit more information at the following location:

http://stackoverflow.com/questions/32738415/supervisor-fails-to-restart-half-of-the-time

Typical error when doing a restart with supervisor already running:

```
[....] Restarting supervisor (via systemctl): supervisor.serviceJob for supervisor.service failed. See 'systemctl status supervisor.service' and 'journalctl -xn' for details.
 failed!
```
